### PR TITLE
Bugfix/#18 disable problematic minifier option, replace special characters with unicode escapes

### DIFF
--- a/src/app/lib/shopHostnameUtils.js
+++ b/src/app/lib/shopHostnameUtils.js
@@ -14,7 +14,7 @@ const SHOP_HOSTNAME_LOOKUP = {
   'o2 germany': 'o2online',
   'floraprima blumenversand': 'floraprima',
   'apo-discounter.de': 'apodiscounter',
-  'erwin müller': 'erwinmueller',
+  'erwin m\xfcller': 'erwinmueller',
   'spiele max': 'spielemax.de',
   'depot online-shop': 'depot-online',
   'babor cosmetics': 'babor',
@@ -26,7 +26,7 @@ const SHOP_HOSTNAME_LOOKUP = {
   'van graaf': 'vangraaf',
   'bofrost*': 'bofrost',
   'fleurop blumenversand': 'fleurop',
-  'neckermann macht´s möglich! - möbel, heimtextilien': 'neckermann',
+  'neckermann macht\xB4s m\xf6glich! - m\xf6bel, heimtextilien': 'neckermann',
   'lands\' end': 'landsend',
   'the body shop': 'thebodyshop',
   'takko fashion': 'takko',
@@ -40,7 +40,7 @@ const SHOP_HOSTNAME_LOOKUP = {
   'allyouneed fresh': 'allyouneedfresh',
   'versandhaus wenz': 'wenz',
   'ctshirts.com - charles tyrwhitt': 'ctshirts',
-  'i´m walking': 'imwalking',
+  'i\xB4m walking': 'imwalking',
   'house of gerry weber': 'house-of-gerryweber',
   'runners point': 'runnerspoint',
   'microsoft store': 'microsoft',
@@ -50,18 +50,18 @@ const SHOP_HOSTNAME_LOOKUP = {
   disneystore: 'shopdisney',
   'camp david & soccx': 'campdavid-soccx',
   'g data software ag': 'gdatasoftware',
-  'hellweg - die profi-baumärkte': 'hellweg',
+  'hellweg - die profi-baum\xe4rkte': 'hellweg',
   'kaspersky lab': 'kaspersky',
   miamoda: 'mia-moda',
   'hertha bsc': 'herthabsc',
   'alba berlin': 'albaberlin',
-  'eisbären berlin': 'eisbaeren',
-  'füchse berlin': 'fuechse',
+  'eisb\xe4ren berlin': 'eisbaeren',
+  'f\xfcchse berlin': 'fuechse',
   'sc dhfk leipzig': 'scdhfk-handball',
   'sc magdeburg': 'scm-handball',
   'handball wm 2019': 'handball19',
-  'frischauf! göppingen': 'frischauf-gp',
-  'hunkemöller': 'hunkemoller'
+  'frischauf! g\xf6ppingen': 'frischauf-gp',
+  'hunkem\xf6ller': 'hunkemoller'
 };
 
 function shopHostnameMatch(targetHostname) {
@@ -80,9 +80,9 @@ export function shopNameToHostname(shopName) {
     .replace('&', ' and ')
     .replace(/\s/g, '-')
     .replace('\'', '-')
-    .replace('ö', 'oe')
-    .replace('ä', 'ae')
-    .replace('ü', 'ue');
+    .replace('\xf6', 'oe')
+    .replace('\xe4', 'ae')
+    .replace('\xfc', 'ue');
 }
 
 export function findActiveShop(shops, hostname) {

--- a/src/babel.config.js
+++ b/src/babel.config.js
@@ -11,7 +11,9 @@ module.exports = function (api) {
     ]
   ];
 
-  const plugins = [];
+  const plugins = [
+    '@babel/plugin-transform-template-literals'
+  ];
 
   return {
     presets,

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -3672,14 +3672,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3699,8 +3697,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -3848,7 +3845,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/src/package.json
+++ b/src/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
+    "@babel/plugin-transform-template-literals": "^7.2.0",
     "@babel/preset-env": "^7.3.1",
     "babel-loader": "^8.0.5",
     "babel-minify-webpack-plugin": "^0.3.1",

--- a/src/webpack-pipeline/background.config.js
+++ b/src/webpack-pipeline/background.config.js
@@ -22,6 +22,8 @@ module.exports = Object.assign({}, commonConfig, {
         to: 'images/'
       }
     ]),
-    new MinifyPlugin()
+    new MinifyPlugin({}, {
+      comments: false
+    })
   ]
 });

--- a/src/webpack-pipeline/background.config.js
+++ b/src/webpack-pipeline/background.config.js
@@ -22,7 +22,10 @@ module.exports = Object.assign({}, commonConfig, {
         to: 'images/'
       }
     ]),
-    new MinifyPlugin({}, {
+    new MinifyPlugin({
+      propertyLiterals: false
+    },
+    {
       comments: false
     })
   ]

--- a/src/webpack-pipeline/dkbContent.config.js
+++ b/src/webpack-pipeline/dkbContent.config.js
@@ -11,7 +11,10 @@ module.exports = Object.assign({}, commonConfig, {
     path: path.resolve(__dirname, '../dist/dkb-content')
   },
   plugins: [
-    new MinifyPlugin({}, {
+    new MinifyPlugin({
+      propertyLiterals: false
+    },
+    {
       comments: false
     })
   ]

--- a/src/webpack-pipeline/dkbContent.config.js
+++ b/src/webpack-pipeline/dkbContent.config.js
@@ -11,6 +11,8 @@ module.exports = Object.assign({}, commonConfig, {
     path: path.resolve(__dirname, '../dist/dkb-content')
   },
   plugins: [
-    new MinifyPlugin()
+    new MinifyPlugin({}, {
+      comments: false
+    })
   ]
 });

--- a/src/webpack-pipeline/options.config.js
+++ b/src/webpack-pipeline/options.config.js
@@ -29,7 +29,10 @@ module.exports = Object.assign({}, commonConfig, {
       assets: ['options.css'],
       append: true
     }),
-    new MinifyPlugin({}, {
+    new MinifyPlugin({
+      propertyLiterals: false
+    },
+    {
       comments: false
     })
   ]

--- a/src/webpack-pipeline/options.config.js
+++ b/src/webpack-pipeline/options.config.js
@@ -29,6 +29,8 @@ module.exports = Object.assign({}, commonConfig, {
       assets: ['options.css'],
       append: true
     }),
-    new MinifyPlugin()
+    new MinifyPlugin({}, {
+      comments: false
+    })
   ]
 });

--- a/src/webpack-pipeline/popup.config.js
+++ b/src/webpack-pipeline/popup.config.js
@@ -29,9 +29,11 @@ module.exports = Object.assign({}, commonConfig, {
       assets: ['popup.css'],
       append: true
     }),
-    // TODO: The minifier breaks the code currently
-    // new MinifyPlugin({}, {
-    //   comments: false
-    // })
+    new MinifyPlugin({
+      propertyLiterals: false
+    },
+    {
+      comments: false
+    })
   ]
 });

--- a/src/webpack-pipeline/popup.config.js
+++ b/src/webpack-pipeline/popup.config.js
@@ -29,6 +29,9 @@ module.exports = Object.assign({}, commonConfig, {
       assets: ['popup.css'],
       append: true
     }),
-    new MinifyPlugin()
+    // TODO: The minifier breaks the code currently
+    // new MinifyPlugin({}, {
+    //   comments: false
+    // })
   ]
 });


### PR DESCRIPTION
Fixes: #18 
=======

Changes:
- disable propertyLiterals minifier option since it breaks code that contains string property names
- replace special characters with unicode escapes
